### PR TITLE
Kubernentes helm installation

### DIFF
--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -39,13 +39,13 @@ helm install edgedelta edgedelta/edgedelta --set apiKey=<API-KEY> -n edgedelta -
 
 3. To set your **API-KEY**, you can use either **apiKey** or **secretApiKey** in the values.yml file.
 
-If you use **apiKey**, then **apiKey** will be kept in clear text as part of your pod property. Change the values.yml file. Review the following example:  
+  - If you use **apiKey**, then **apiKey** will be kept in clear text as part of your pod property. Change the values.yml file. Review the following example:  
 
 ```yaml
 apiKey: "API-KEY"
 ```
 
-If you want to use **secretApiKey** as a Kubernetes secret, then you must change the values.yml file. Review the following example:  
+  - If you want to use **secretApiKey** as a Kubernetes secret, then you must change the values.yml file. Review the following example:  
 
 ```yaml
 # apiKey: ""
@@ -55,7 +55,7 @@ secretApiKey:
   key: "ed-api-key"
 ```
 
-You need to create **API-KEY** as a Kubernetes secret. Review the following example:  
+4. Create **API-KEY** as a Kubernetes secret. Review the following example:  
 
 ```text
 kubectl create namespace edgedelta

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -11,7 +11,7 @@ You can use this document to learn how to install the Edge Delta Agent as a Daem
 
 The agent is a daemon that analyzes logs and container metrics from a Kubernetes cluster, and then streams analytics to configured streaming destinations.
 
-Edge Delta uses a Kubernetes-recommended, node-level logging architecture, also known as a DaemonSet architecture. The DaemonSet runs the agent pod on each node. Each agent pod analyzes logs from all other pods running on the same node.
+Edge Delta uses a Kubernetes-recommended, node-level log collecting architecture, also known as a DaemonSet architecture. The DaemonSet runs the agent pod on each node. Each agent pod analyzes logs from all other pods running on the same node.
 
 > **Note**
 >

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -5,37 +5,47 @@ description: >-
   have conceptual understanding of helm charts
 ---
 
-# Kubernetes via Helm
+## Overview
 
-Edge Delta agent is a daemon that analyzes logs and container metrics from a Kubernetes cluster and stream analytics to configured streaming destinations. This page streamlined instructions to get you up and running in the Kubernetes environment.
+You can use this document to learn how to install the Edge Delta Agent as a DaemonSet on your Kubernetes cluster with Helm.
 
-Edge Delta uses Kubernetes recommended node level logging architecture, in other words DaemonSet architecture. The DaemonSet runs Edge Delta agent pod on each node. Each Agent pod analyzes logs from all other pods running on the same node.
+The agent is a daemon that analyzes logs and container metrics from a Kubernetes cluster, and then streams analytics to configured streaming destinations.
 
-## Installation
+Edge Delta uses a Kubernetes-recommended, node-level logging architecture, also known as a DaemonSet architecture. The DaemonSet runs the agent pod on each node. Each agent pod analyzes logs from all other pods running on the same node.
 
-Add Edge Delta helm repository
+> **Note**
+>
+> This document is designed for existing users. If you have not created an account with Edge Delta, then see [Basic Onboarding](/docs/basic-onboarding.md).
+
+> **Note**
+>
+> If you do **not** want to install the agent on your Kubernetes with Helm, then see [Kubernetes](kubernetes.md).
+
+***
+
+## Add and Configure Helm
+
+1. Add the Edge Delta Helm repository:
 
 ```text
 helm repo add edgedelta https://edgedelta.github.io/charts
 ```
 
-Run helm installation command and create "edgedelta" namespace to use agent with default parameters:
+2. Run the helm installation command, and then create the **edgedelta** namespace to use the Edge Delta Agent with default parameters:
 
 ```text
 helm install edgedelta edgedelta/edgedelta --set apiKey=<API-KEY> -n edgedelta --create-namespace
 ```
 
-If you need to configure [Environment Variables](environment-variables.md) and other advanced options download the default [values.yml](https://edgedelta.github.io/charts/edgedelta/values.yaml) file.
+3. To set your **API-KEY**, you can use either **apiKey** or **secretApiKey** in the values.yml file.
 
-You can use either apiKey or secretApiKey in values.yml file to set your API-KEY.
-
-If you use apiKey it will be kept in clear text as part of your pod property. Change values.yml file as below:
+If you use **apiKey**, then **apiKey** will be kept in clear text as part of your pod property. Change the values.yml file. Review the following example:  
 
 ```yaml
 apiKey: "API-KEY"
 ```
 
-If you want to use secretApiKey as a Kubernetes secret, change values.yml as below:
+If you want to use **secretApiKey** as a Kubernetes secret, then you must change the values.yml file. Review the following example:  
 
 ```yaml
 # apiKey: ""
@@ -45,22 +55,25 @@ secretApiKey:
   key: "ed-api-key"
 ```
 
-You need to create API-KEY as a Kubernetes secret using command below:
+You need to create **API-KEY** as a Kubernetes secret. Review the following example:  
 
 ```text
 kubectl create namespace edgedelta
 kubectl create secret generic ed-api-key --namespace=edgedelta --from-literal=ed-api-key="API-KEY"
 ```
 
-You can also add environment variables or refer secrets as environment variables using commented samples in the values.yml file.
+> **Note**
+>
+> You can also add environment variables or refer secrets as environment variables using commented samples in the values.yml file. For additional environment variables, you can download and edit [https://edgedelta.github.io/k8s/edgedelta-agent.yml](https://edgedelta.github.io/k8s/edgedelta-agent.yml). To learn more, review the [Environment Variables](https://docs.edgedelta.com/installation/environment-variables/) document, specially the **Examples - Kubernetes (yml configuration) section**. 
 
-Use below command to install helm chart using values.yml in the same folder:
+
+5. Use the following command to install helm chart using values.yml in the same folder:
 
 ```text
 helm install edgedelta edgedelta/edgedelta -n edgedelta --create-namespace -f values.yaml
 ```
 
-Output
+6. Review the following output: 
 
 ```text
 NAME: edgedelta
@@ -74,12 +87,14 @@ NOTES:
 2. Find the configuration with <API-KEY> to check if agents are active
 ```
 
-Show helm installed packages in "edgedelta" namespace
+7. To show helm installed packages in "edgedelta" namespace, review the following command:
 
 ```text
 helm ls -n edgedelta
 ```
-## Value.yml Paramaters
+***
+
+## Review Value.yml Paramaters
 
 | Name | Description | Example Value |
 | :--- | :--- | :--- |
@@ -100,11 +115,14 @@ helm ls -n edgedelta
 | resources.requests.memory | Minimum requested memory for agent pod |256Mi |
 | image | Agent docker image | edgedelta/agent |
 
+***
 
-## Useful Tips
+## Uninstall helm chart
 
-### Uninstall helm chart
+To uninstall the helm chart:
 
 ```text
 helm delete edgedelta -n edgedelta
 ```
+
+***

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -24,13 +24,13 @@ Edge Delta uses a Kubernetes-recommended, node-level log collecting architecture
 ***
 
 
-## Step 1: Create, Download, and Install the Agent 
+## Install the Agent via Helm 
 
 1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**. 
 3. Select **Helm**.
 4. Click **Save**.  
-5. In the table, locate the newly created agent, and then click the corresponding green rocket to deploy additional instructions. 
+5. In the table, locate the newly created agent configuration, and then click the corresponding green rocket to deploy additional instructions. 
 6. Click **Helm**. 
 7. In the window that appears, follow the on-screen instructions. 
   - This window also displays your API key.  
@@ -140,7 +140,7 @@ helm ls -n edgedelta
 
 ***
 
-## Uninstall Helm Chart
+## Uninstall Helm Release
 
 To uninstall the helm chart:
 

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -100,8 +100,6 @@ NOTES:
 2. Find the configuration with <API-KEY> to check if agents are active
 ```
 
--->
-
 
 8. In the same folder, install the helm chart using values.yml:
 
@@ -109,7 +107,9 @@ NOTES:
 helm install edgedelta edgedelta/edgedelta -n edgedelta --create-namespace -f values.yaml
 ```
 
-9. View helm-installed packages in the **edgedelta** namespace:
+-->
+
+8. View helm-installed packages in the **edgedelta** namespace:
 
 ```
 helm ls -n edgedelta

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -15,7 +15,7 @@ Edge Delta uses a Kubernetes-recommended, node-level log collecting architecture
 
 > **Note**
 >
-> This document is designed for existing users. If you have not created an account with Edge Delta, then see [Basic Onboarding](/docs/basic-onboarding.md).
+> This document is designed for existing users. If you have not created an account with Edge Delta, then see [Basic Onboarding](../basic-onboarding.md).
 
 > **Note**
 >

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -39,13 +39,17 @@ helm install edgedelta edgedelta/edgedelta --set apiKey=<API-KEY> -n edgedelta -
 
 3. To set your **API-KEY**, you can use either **apiKey** or **secretApiKey** in the values.yml file.
 
-  - If you use **apiKey**, then **apiKey** will be kept in clear text as part of your pod property. Change the values.yml file. Review the following example:  
+  - To use **apiKey** as a Kubernetes secret, change the values.yml file: 
 
 ```yaml
 apiKey: "API-KEY"
 ```
 
-  - If you want to use **secretApiKey** as a Kubernetes secret, then you must change the values.yml file. Review the following example:  
+> **Note**
+> 
+> **apiKey** will be kept in clear text as part of your pod property.
+
+  - To use **secretApiKey** as a Kubernetes secret, change the values.yml file: 
 
 ```yaml
 # apiKey: ""
@@ -55,7 +59,7 @@ secretApiKey:
   key: "ed-api-key"
 ```
 
-4. Create **API-KEY** as a Kubernetes secret. Review the following example:  
+4. Create **API-KEY** as a Kubernetes secret:
 
 ```text
 kubectl create namespace edgedelta
@@ -67,7 +71,7 @@ kubectl create secret generic ed-api-key --namespace=edgedelta --from-literal=ed
 > You can also add environment variables or refer secrets as environment variables using commented samples in the values.yml file. For additional environment variables, you can download and edit [https://edgedelta.github.io/k8s/edgedelta-agent.yml](https://edgedelta.github.io/k8s/edgedelta-agent.yml). To learn more, review the [Environment Variables](https://docs.edgedelta.com/installation/environment-variables/) document, specially the **Examples - Kubernetes (yml configuration) section**. 
 
 
-5. Use the following command to install helm chart using values.yml in the same folder:
+5. Install helm chart using values.yml in the same folder:
 
 ```text
 helm install edgedelta edgedelta/edgedelta -n edgedelta --create-namespace -f values.yaml
@@ -87,14 +91,15 @@ NOTES:
 2. Find the configuration with <API-KEY> to check if agents are active
 ```
 
-7. To show helm installed packages in "edgedelta" namespace, review the following command:
+7. View helm-installed packages in the "edgedelta" namespace:
 
 ```text
 helm ls -n edgedelta
 ```
+
 ***
 
-## Review Value.yml Paramaters
+## Review Value.yml Parameters
 
 | Name | Description | Example Value |
 | :--- | :--- | :--- |

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -23,17 +23,33 @@ Edge Delta uses a Kubernetes-recommended, node-level log collecting architecture
 
 ***
 
+
+## Step 1: Create, Download, and Install the Agent 
+
+1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+2. Click **Create Configuration**. 
+3. Select **Helm**.
+4. Click **Save**.  
+5. In the table, locate the newly created agent, and then click the corresponding green rocket to deploy additional instructions. 
+6. Click **Helm**. 
+7. In the window that appears, follow the on-screen instructions. 
+  - This window also displays your API key.  
+
+<!--
+
+
+
 ## Add and Configure Helm
 
 1. Add the Edge Delta Helm repository:
 
-```text
+```
 helm repo add edgedelta https://edgedelta.github.io/charts
 ```
 
 2. Run the helm installation command, and then create the **edgedelta** namespace to use the Edge Delta Agent with default parameters:
 
-```text
+```
 helm install edgedelta edgedelta/edgedelta --set apiKey=<API-KEY> -n edgedelta --create-namespace
 ```
 
@@ -61,7 +77,7 @@ secretApiKey:
 
 4. Create **API-KEY** as a Kubernetes secret:
 
-```text
+```
 kubectl create namespace edgedelta
 kubectl create secret generic ed-api-key --namespace=edgedelta --from-literal=ed-api-key="API-KEY"
 ```
@@ -70,16 +86,9 @@ kubectl create secret generic ed-api-key --namespace=edgedelta --from-literal=ed
 >
 > You can also add environment variables or refer secrets as environment variables using commented samples in the values.yml file. For additional environment variables, you can download and edit [https://edgedelta.github.io/k8s/edgedelta-agent.yml](https://edgedelta.github.io/k8s/edgedelta-agent.yml). To learn more, review the [Environment Variables](https://docs.edgedelta.com/installation/environment-variables/) document, specially the **Examples - Kubernetes (yml configuration) section**. 
 
+9. Review the following output: 
 
-5. Install helm chart using values.yml in the same folder:
-
-```text
-helm install edgedelta edgedelta/edgedelta -n edgedelta --create-namespace -f values.yaml
 ```
-
-6. Review the following output: 
-
-```text
 NAME: edgedelta
 LAST DEPLOYED: Fri Jul 17 17:49:42 2020
 NAMESPACE: edgedelta
@@ -91,9 +100,18 @@ NOTES:
 2. Find the configuration with <API-KEY> to check if agents are active
 ```
 
-7. View helm-installed packages in the "edgedelta" namespace:
+-->
 
-```text
+
+8. In the same folder, install the helm chart using values.yml:
+
+```
+helm install edgedelta edgedelta/edgedelta -n edgedelta --create-namespace -f values.yaml
+```
+
+9. View helm-installed packages in the **edgedelta** namespace:
+
+```
 helm ls -n edgedelta
 ```
 
@@ -122,11 +140,11 @@ helm ls -n edgedelta
 
 ***
 
-## Uninstall helm chart
+## Uninstall Helm Chart
 
 To uninstall the helm chart:
 
-```text
+```
 helm delete edgedelta -n edgedelta
 ```
 

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -15,10 +15,13 @@ The agent is a daemon that analyzes logs and container metrics from a Kubernetes
 
 Edge Delta uses a Kubernetes-recommended, node-level logging architecture, also known as a DaemonSet architecture. The DaemonSet runs the agent pod on each node. Each agent pod analyzes logs from all other pods running on the same node.
 
-
 > **Note**
 >
 > This document is designed for existing users. If you have not created an account with Edge Delta, then see [Basic Onboarding](/docs/basic-onboarding.md).
+
+> **Note**
+>
+> If you want to install the agent on your Kubernetes via Helm, then see [Kubernetes via Helm](helm.md).
 
 ***
 


### PR DESCRIPTION
I have revised the Kubernetes - Helm installation documentation. 

I would appreciate a quick review of the **Add and Configure Helm** section. 

The order of the instructions seemed off because we tell the user to create a namespace with the API key, and then later on, we tell the user how to configure their API key. I just wanted to make sure that the workflow is correct. 

Also, does the user grab their API key from the portal? If so, in the Agent Settings screen, which key do they grab? For instance, in my account, I see a key for "kubernetes_example." Is that a typical user would see? 