### PR TITLE
Remove release notes page

### DIFF
--- a/docs/agent-requirements.md
+++ b/docs/agent-requirements.md
@@ -30,7 +30,7 @@ You can use this document to review software and hardware requirements before yo
 
 ## Browser Support
   
-The Edge Delta Admin portal supports the current version of the following browsers:
+The Edge Delta App portal supports the current version of the following browsers:
   - Chrome
   - Firefox
   - Edge
@@ -41,7 +41,7 @@ The Edge Delta Admin portal supports the current version of the following browse
   
 > **Note**
 > 
-> Edge Delta does not recommend that you use a mobile device to access the Edge Delta Admin portal.
+> Edge Delta does not recommend that you use a mobile device to access the Edge Delta App portal.
 
 ***
 
@@ -63,12 +63,4 @@ Review the following network access requirements to ensure a successful connecti
 
 ***
   
-## Additional Documentation
-  
-Outputs to 3rd party or on-premise systems also require outbound network access. When you configure the agent, verify that the **endpoint** of the configured output is also accessible by the agent through the network. Outputs instruct the agent where to send collected and generated data, such as metrics, patterns, and alerts.
-
-  * To learn more, see [Outputs](./configuration/outputs.md).  
-  
-  
-***  
   

--- a/docs/agent-requirements.md
+++ b/docs/agent-requirements.md
@@ -30,7 +30,7 @@ You can use this document to review software and hardware requirements before yo
 
 ## Browser Support
   
-The Edge Delta App portal supports the current version of the following browsers:
+The Edge Delta App supports the current version of the following browsers:
   - Chrome
   - Firefox
   - Edge
@@ -41,7 +41,7 @@ The Edge Delta App portal supports the current version of the following browsers
   
 > **Note**
 > 
-> Edge Delta does not recommend that you use a mobile device to access the Edge Delta App portal.
+> Edge Delta does not recommend that you use a mobile device to access the Edge Delta App.
 
 ***
 

--- a/docs/appendices/azure-serverless-monitoring.md
+++ b/docs/appendices/azure-serverless-monitoring.md
@@ -16,13 +16,13 @@ This document explains how to deploy Edge Delta components to an AKS cluster.
 
 ## Step 1: Set Up the Edge Delta Processor in an AKS Cluster
 
-1. Create a new config in the [Edge Delta Admin portal](https://admin.edgedelta.com/) with the content from [this file](https://raw.githubusercontent.com/edgedelta/docs/master/docs/appendices/aks_appinsight_trace_processor_agent_config.yaml).
+1. Create a new config in the [Edge Delta App](https://app.edgedelta.com/) with the content from [this file](https://raw.githubusercontent.com/edgedelta/docs/master/docs/appendices/aks_appinsight_trace_processor_agent_config.yaml).
 
 2. Replace **INSTRUMENTATION\_KEY** with your the instrumentation key.
 
 3. Create a new AKS cluster or use an existing cluster.
 
-4. Add a new node pool on AKS with the sepcs below. 
+4. Add a new node pool on AKS with the specs below. 
 
    * If you skip this step, then update the nodeSelector in [ed-appinsights-trace-processor.yaml](https://raw.githubusercontent.com/edgedelta/docs/master/docs/appendices/ed-appinsights-trace-processor.yaml).
 

--- a/docs/appendices/okta-saml.md
+++ b/docs/appendices/okta-saml.md
@@ -42,10 +42,10 @@ You can use this document to learn how to set up an Okta SAML integration with E
 13. In Okta, register your users to use SAML authentication. 
     * To learn more, review this [article from Okta](https://help.okta.com/en/prod/Content/Topics/users-groups-profiles/usgp-add-users.htm). 
 14. Visit https://admin.edgedelta.com/saml , and then enter your Okta credentials. You will be redirected to Okta. 
-15. Enter your Okta credentials, and then you will be redirected to the Edge Delta Admin portal. 
+15. Enter your Okta credentials, and then you will be redirected to the Edge Delta App. 
 
 > **Note**
 > 
-> When you use the same browser to access the Edge Delta Admin portal, by default SAML authentication will take place. 
+> When you use the same browser to access the Edge Delta App, by default SAML authentication will take place. 
 
 ***

--- a/docs/appendices/on-prem-rehydration.md
+++ b/docs/appendices/on-prem-rehydration.md
@@ -28,14 +28,14 @@ By default, the Edge Delta agent archives logs on customer S3 buckets owned by E
 
   * This action can be disabled for user-owned S3 buckets. 
 
-A custom S3 bucket (or GCS, Blob, Minio, etc.) can be created in the Integrations page of the Edge Delta Admin portal. 
+A custom S3 bucket (or GCS, Blob, Minio, etc.) can be created in the Integrations page of the Edge Delta App. 
 After you create and add the bucket to a workflow in the agent configuration, the agent will start to send gzipped logs to the custom bucket.
 
 **Rehydration**
 
 Rehydration is the process of pushing already-archived data to a target streaming platform, such as Splunk, Elasticsearch, etc.
 
-You can use the Rehydration section of the Edge Delta Admin portal to initiate a rehydration for a specific time range, source filter, and keyword filters.
+You can use the Rehydration section of the Edge Delta App to initiate a rehydration for a specific time range, source filter, and keyword filters.
 
 By default, the Edge Delta backend handles rehydrations. Rehydration handlers will: 
     
@@ -81,7 +81,7 @@ helm upgrade openfaas --wait --install openfaas/openfaas \
     -f https://raw.githubusercontent.com/edgedelta/docs/master/docs/appendices/on-prem-rehydration-helm-values.yml;
 ```
 
-3.Access the Edge Delta Admin portal, specifically the [Global Settings](https://app.edgedelta.com/global-settings) page, and then create an Edge Delta token with the following permissions: 
+3.Access the Edge Delta App, specifically the [Global Settings](https://app.edgedelta.com/global-settings) page, and then create an Edge Delta token with the following permissions: 
 
   - Write permission on Rehydration resources
   - Read permission on Integration resources
@@ -98,7 +98,7 @@ kubectl create secret generic ed-rehydration-token \
   --from-literal=ed-rehydration-token="<token value goes here>"
 ```
 
-5.Access the Edge Delta Admin portal, specifically the [Rehydrations](https://app.edgedelta.com/rehydrations) page, click **Settings**, and then enable **On Prem Rehydration** for your organization's rehydrations.
+5.Access the Edge Delta App, specifically the [Rehydrations](https://app.edgedelta.com/rehydrations) page, click **Settings**, and then enable **On Prem Rehydration** for your organization's rehydrations.
 
 > **Note**
 > 
@@ -141,7 +141,7 @@ kubectl logs deployment/rehydration-poller -n edgedelta-rehydration
 ```
 
 
-12.Return to the [Rehydrations](https://app.edgedelta.com/rehydrations) page in the portal, and then create rehydration requests. 
+12.Return to the [Rehydrations](https://app.edgedelta.com/rehydrations) page in the app, and then create rehydration requests. 
 
 The requests will be processed by the rehydration components that was just installed on your k8s cluster.
 
@@ -166,7 +166,7 @@ Review the following prerequisites:
 kubectl create namespace edgedelta-rehydration
 ```
 
-2.Access the Edge Delta Admin portal, specifically the [Global Settings](https://app.edgedelta.com/global-settings) page, and then create an Edge Delta token with the following permissions: 
+2.Access the Edge Delta App, specifically the [Global Settings](https://app.edgedelta.com/global-settings) page, and then create an Edge Delta token with the following permissions: 
 
     * Write permission on Rehydration resources
     * Read permission on Integration resources
@@ -183,7 +183,7 @@ kubectl create secret generic ed-rehydration-token \
   --from-literal=ed-rehydration-token="<token value goes here>"
 ```
 
-4.Access the Edge Delta Admin portal, specifically the [Rehydrations](https://app.edgedelta.com/rehydrations) page, click **Settings**, and then enable **On Prem Rehydration** for your organization's rehydrations.
+4.Access the Edge Delta App, specifically the [Rehydrations](https://app.edgedelta.com/rehydrations) page, click **Settings**, and then enable **On Prem Rehydration** for your organization's rehydrations.
 
 > **Note**
 > 
@@ -218,7 +218,7 @@ kubectl logs deployment/rehydration-poller -n edgedelta-rehydration
 ```
 
 
-10.Return to the [Rehydrations](https://app.edgedelta.com/rehydrations) page in the portal, and then create rehydration requests. 
+10.Return to the [Rehydrations](https://app.edgedelta.com/rehydrations) page in the app, and then create rehydration requests. 
 
 The requests will be processed by the rehydration components that was just installed on your k8s cluster.
 

--- a/docs/appendices/tokens.md
+++ b/docs/appendices/tokens.md
@@ -39,7 +39,7 @@ After you create the token, the unique token key will only display once. Afterwa
 > 
 > You can only create a token based on the permisssions that you already have. For example, if you have read-only access for **Integrations**, then you can create a token with read-only access for **Integrations**; however, you cannot create a token with write-only access for **Integrations** because you do not currently have that permission. 
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Global Settings**. 
+1. In the Edge Delta App, on the left-side navigation, click **Global Settings**. 
 2. In the Tokens sections, click  **Create Token**. 
 3. Under **Name**, enter a descriptive name for the token, such as **john-smith-integrations-token**. 
 4. Click **Add Permissions**.
@@ -53,7 +53,7 @@ After you create the token, the unique token key will only display once. Afterwa
 10. Click **Token Details**. 
 11. Review the list of permissions, and then click **Create**.
 12. In the window that appears, copy and save the token.
-  - Remember, Edge Delta does not store tokens. As a result, a lost or missplaced token cannot be retrieved. 
+  - Remember, Edge Delta does not store tokens. As a result, a lost or misplaced token cannot be retrieved. 
 13. Click **Close**. 
 14. The newly created token will be listed in the **Tokens** table. 
 15. You can use the newly created token to make API calls to the Edge Delta backend system. Tokens should be sent in the **X-ED-API-Token** request header.
@@ -76,7 +76,7 @@ Review the following table to understand the information listed in the **Tokens*
 
 ## Delete a Token 
   
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Global Settings**.   
+1. In the Edge Delta App, on the left-side navigation, click **Global Settings**.   
 2. Navigate to **Tokens**.
 3. Under **Actions**, click the trash icon for the corresponding token. 
 4. Click **Yes** to confirm your action. 

--- a/docs/basic-onboarding.md
+++ b/docs/basic-onboarding.md
@@ -26,14 +26,14 @@ You can use this document to learn how to:
 
 ## Step 1: Access Edge Delta
 
-1. Navigate to [admin.edgedelta.com](https://admin.edgedelta.com/), and then click **Sign up**.
-2. Complete the missing fields, and then click **Register**. You will be redirected to the **Welcome to Edge Delta** screen in the Edge Delta Admin portal.
+1. Navigate to [app.edgedelta.com](https://app.edgedelta.com/), and then click **Sign up**.
+2. Complete the missing fields, and then click **Register**. You will be redirected to the **Welcome to Edge Delta** screen in the Edge Delta App.
 
 ***
 
 ## Step 2: Deploy the Agent
 
-1. In the Edge Delta Admin portal, select your operating platform.
+1. In the Edge Delta App, select your operating platform.
 2. In **Enter Environment Tag**, enter a descriptive tag to explain where the agent will be deployed.
 3. Click **Continue**.
 4. Select a destination type to create an organization-level output to send data from Edge Delta.
@@ -41,7 +41,7 @@ You can use this document to learn how to:
     * To learn more about outputs, including parameters, see [Outputs](configuration/outputs.md). 
 6. Copy the pre-populated agent command.
 7. Open a terminal or command line prompt, then paste and run the command.  
-8. In the portal, click **I Ran Deploy Commands**.
+8. In the app, click **I Ran Deploy Commands**.
 9. The agent will take a few minutes to deploy and authenticate with Edge Delta.
 10. After a successful deployment, click **Go To Status Page**.
     * In the window that appears, you can click **Go To Demo Environment** to see a pre-populated account where you can view and test data.
@@ -54,20 +54,20 @@ You can use this document to learn how to:
 
 There are 2 ways to verify agent deployment:
 
-  * In the portal
+  * In the app
   * In the target software platform
 
 ***
 
-### Option 1: Verify Agent Deployment in the Portal
+### Option 1: Verify Agent Deployment in the App
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, under **Data Pipeline**, click **Pipeline Status**.
+1. In the Edge Delta App, on the left-side navigation, under **Data Pipeline**, click **Pipeline Status**.
 2. Review the **Active Nodes** section.
 3. If the agent was successfully installed, then there will be at least 1 active node.
 
 >  **Note**
 >
-> After an initial agent deployment, the portal may only display non-zero values.
+> After an initial agent deployment, the app may only display non-zero values.
 
 ***
 

--- a/docs/configuration/agent-settings.md
+++ b/docs/configuration/agent-settings.md
@@ -25,7 +25,7 @@ At a high level, there are 2 ways to manage **Agent Settings**:
 
 **To access the visual editor for a new configuration:** 
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Agent Settings**. 
@@ -33,7 +33,7 @@ At a high level, there are 2 ways to manage **Agent Settings**:
 
 **To access the YAML file for an existing configuration:** 
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file.
 

--- a/docs/configuration/ccb.md
+++ b/docs/configuration/ccb.md
@@ -12,7 +12,7 @@ You can use this document to learn how to create and manage the Edge Delta Cloud
 
 The CCB is a service provided by Edge Delta to help generate and deploy configuration files used by the Edge Delta service.
 
-With the CCB, you can use the Edge Delta Admin portal to create and manage configuration files. The CCB also automatically generates configuration API keys that are used to pre-configure agents during deployment.
+With the CCB, you can use the Edge Delta App to create and manage configuration files. The CCB also automatically generates configuration API keys that are used to pre-configure agents during deployment.
 
 Additionally, CCB allows you to update and modify configuration files directly through the portal, which automatically propagates changes down to running agents.
 
@@ -30,7 +30,7 @@ There are 2 ways to create a configuration:
 
 **Option 1: Use a template with default settings**
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select a template, and then click **Save**.
 4. Refresh the screen to view the newly created configuration in the table.
@@ -46,7 +46,7 @@ As an optional step, you can view and update the configurations in the template.
 
 **Option 2: Use a visual editor to populate a YAML file**
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select a configuration option. In the empty field, enter your configurations. When you are done, click the back button on top of the form to return to the list of configuration options. **Do not click Save.**  
@@ -61,9 +61,9 @@ As an optional step, you can view and update the configurations in the template.
 
 ## View Configuration History
 
-Any change made to a configuration will be tracked and displayed in the Edge Delta Admin portal.
+Any change made to a configuration will be tracked and displayed in the Edge Delta App.
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Review the listed entries.
 3. To filter for specific entry types, click **Filter** and then mark a filter option.
 4. To view a diff, locate the desired configuration, and then under **Actions**, click the corresponding diff icon.
@@ -75,7 +75,7 @@ Any change made to a configuration will be tracked and displayed in the Edge Del
 
 ## Update an Existing Configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Make your changes, and then click **Save**.
 4. A new entry will appear in the table, with the date and time of the update.
@@ -86,7 +86,7 @@ After you update a configuration via the portal, the updated configuration versi
 
 ## Configure File Management Locally
 
-While you can use the Cloud Configuration Backend \(CCB\) in the Edge Delta Admin portal to update a configuration, you can also manage and deploy configuration files locally, with tools such as Chef, Puppet, Ansible, Salt, Terraform, etc.  
+While you can use the Cloud Configuration Backend \(CCB\) in the Edge Delta App to update a configuration, you can also manage and deploy configuration files locally, with tools such as Chef, Puppet, Ansible, Salt, Terraform, etc.  
 
 To configure locally, a flag must be provided during agent deployment to let the system know that Local Configuration File Management is in place.
 

--- a/docs/configuration/filters.md
+++ b/docs/configuration/filters.md
@@ -40,7 +40,7 @@ You can create the following filter types:
 
 This filter type passes all log lines that match the specified regular expression. All unmatched logs are discarded.  
 
-In the Edge Delta Admin portal, in the visual editor, when you select **regex** as the filter type, the following fields will appear:
+In the Edge Delta App, in the visual editor, when you select **regex** as the filter type, the following fields will appear:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -77,7 +77,7 @@ This filter type hides (or masks) specific data, based on the configured regex p
 
 This filter type can be useful to hide sensitive data, such as phone numbers, social security numbers, credit card numbers, etc. Specifically, based on the configured regex pattern, this filter type changes the log lines to hide the matched content.
 
-In the Edge Delta Admin portal, in the visual editor, when you select **mask** as the filter type, the following fields will appear:
+In the Edge Delta App, in the visual editor, when you select **mask** as the filter type, the following fields will appear:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -126,7 +126,7 @@ This filter type handles trace logs.
 At a high level, this filter type:
 
   * Groups logs by a specified ID, then
-  * Verifies that all relavant events of that trace (or request) is collected, and then
+  * Verifies that all relevant events of that trace (or request) is collected, and then
   * Discards or passes the trace logs, based on the configuration.
 
 This filter type offers the following pass options: 
@@ -135,14 +135,14 @@ This filter type offers the following pass options:
 * Pass through high-latency operation events
 * Pass through certain percentage of successful events
 
-In the Edge Delta Admin portal, in the visual editor, when you select **buffered-trace** as the filter type, the following fields will appear:
+In the Edge Delta App, in the visual editor, when you select **buffered-trace** as the filter type, the following fields will appear:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
 | name | Enter a descriptive name for this filter. When you create an input, processor, or workflow, this name will appear in the list of filters to select. | Required |
 | trace\_id\_pattern | Enter a regular expression pattern to extract the trace ID values from logs. Enter a regex with single capture group. | Required |
 | failure\_pattern | Enter a regular expression pattern to indicate that a match with the trace event \(group of logs sharing same ID\) is a failure. Failures are passed through this filter. | Required |
-| trace\_deadline | Enter a [golang duration](https://golang.org/pkg/time/#ParseDuration) string to represent the max duration of a trace. Once the specified trace deadline is reached, the buffered trace filter will take all events that belong to the same trace, apply the filters/sampling, and then pass through the relavant events. | Required |
+| trace\_deadline | Enter a [golang duration](https://golang.org/pkg/time/#ParseDuration) string to represent the max duration of a trace. Once the specified trace deadline is reached, the buffered trace filter will take all events that belong to the same trace, apply the filters/sampling, and then pass through the relevant events. | Required |
 | success\_sample\_rate | Enter a number to indicate the percentage of successful traces that you want to receive. You can enter a number between 0 and 1. The default setting is 0, which means all successful traces are discarded. If you enter 0.2, then 20% of successful traces will pass through the filter. **Note** Any trace event without a **failure\_pattern** match indicates successful trace. | Optional |
 | latency\_pattern | Enter a regular expression pattern to extract the latency value from the trace logs. You must enter a regex with a single numeric capture group. Only 1 of the logs that belongs to the same trace ID should have latency information, or the last log will be picked to represent the latency of the trace. Once the latency value is extracted and converted to a number, this value can be used in conjunction with the **latency\_threshold** parameter to pass through high-latency traces. This process is useful to collect the high-latency traces, in addition to the failed traces that already passed throughou, based on the **failure\_pattern** parameter. | Optional |
 | latency\_threshold | Enter a numeric value to represent the threshold for high-latency limit. The latency of a trace is extracted with the **latency\_pattern** parameter. | Optional |
@@ -173,7 +173,7 @@ This filter type extracts a field's value and replaces the whole JSON content wi
 
 When this filter is applied, the original JSON is discarded. As a result, if the original JSON needs to be fed into another workflow or processor, then Edge Delta recommends that you attach this filter to the processor. 
 
-In the Edge Delta Admin portal, in the visual editor, when you select **extract-json-field** as the filter type, the following fields will appear:
+In the Edge Delta App, in the visual editor, when you select **extract-json-field** as the filter type, the following fields will appear:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -216,7 +216,7 @@ At a high level, there are 2 ways to access **Filters**:
 
 ### Option 1: Access the visual editor for a new configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Filters**. 
@@ -230,7 +230,7 @@ At a high level, there are 2 ways to access **Filters**:
 
 ### Option 2: Access the YAML file for an existing configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file, make your changes, and then click **Save**. 
     * To learn about these configurations, see **Step 1: Review Filter Types**.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -26,7 +26,7 @@ The configuration file is automatically loaded into memory at runtime.
 
 Updates to the configuration file are typically made via the CCB \(Central Configuration Backend\), or locally against the file itself.
 
-  * If configuration updates are made in the Edge Delta Admin Portal \(via the CCB\), then the updates are automatically propagated to the agent without a restart.
+  * If configuration updates are made in the Edge Delta App \(via the Cloud Configuration Backend (CCB)\), then the updates are automatically propagated to the agent without a restart.
 
 ***
 

--- a/docs/configuration/inputs.md
+++ b/docs/configuration/inputs.md
@@ -10,7 +10,7 @@ description: >-
 
 You can use this document to learn about the configuration parameters available in a configuration file, specifically for **Inputs**.
 
-An inputs tells the Edge Delta agent:
+An input tells the Edge Delta agent:
 
   * Data types to listen for
   * Data locations
@@ -34,7 +34,7 @@ At a high level, there are 2 ways to manage **Inputs**:
 
 **To access the visual editor for a new configuration:**
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Inputs**.
@@ -42,7 +42,7 @@ At a high level, there are 2 ways to manage **Inputs**:
 
 **To access the YAML file for an existing configuration:**
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file.
 
@@ -496,7 +496,7 @@ This input type allows you to specify a command, set of commands, or scripts to 
 
 ## Kubernetes Events
 
-This input type collects Kubernetes events (namespace independent) and sends these events to the Edge Delta backend, which can be configured to display in the Edge Delta Admin portal, specifically in the **Insights** page.
+This input type collects Kubernetes events (namespace independent) and sends these events to the Edge Delta backend, which can be configured to display in the Edge Delta App, specifically in the **Insights** page.
 
 > **Note**
 >

--- a/docs/configuration/outputs-archives.md
+++ b/docs/configuration/outputs-archives.md
@@ -30,7 +30,7 @@ At a high level, there are 2 ways to manage **Outputs**:
 
 ### Option 1: Access the visual editor for a new configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Archive**.
@@ -46,7 +46,7 @@ At a high level, there are 2 ways to manage **Outputs**:
 
 ### Option 2: Access the YAML file for an existing configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file, make your changes, and then click **Save**. 
 
@@ -93,7 +93,7 @@ Before you configure your Edge Delta account to sends logs to an AWS S3 endpoint
 }
 ```
 
-After you attach the policy in the AWS console, review the following parameters that you can configure in the Edge Delta Admin portal:
+After you attach the policy in the AWS console, review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -128,7 +128,7 @@ The **Azure Blob Storage** output will stream logs to an Azure Blob Storage endp
 > 
 >   * To learn more, review this [document from Microsoft](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal). 
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -162,7 +162,7 @@ The **Google Cloud Storage** output will stream logs to a GCS endpoint.
 > 
 >   * To learn how to create a new key, review this [document from Google](https://cloud.google.com/storage/docs/authentication/managing-hmackeys). 
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -189,7 +189,7 @@ The following example displays an output without the name of the organization-le
 
 The **DigitalOcean Spaces** output will stream logs to a DigitalOcean Spaces endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -218,7 +218,7 @@ The following example displays an output without the name of the organization-le
 
 The **IBM Object Storage** output will stream logs to an IBM Object Storage endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -247,7 +247,7 @@ The following example displays an output without the name of the organization-le
 
 The **Minio** output will stream logs to a Minio endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -280,7 +280,7 @@ The following example displays an output without the name of the organization-le
 
 The **Zenko CloudServer** output will stream logs to a CloudServer endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -309,7 +309,7 @@ The following example displays an output without the name of the organization-le
 
 The **Moogsoft** output will stream notifications and alerts to a specified Moogsoft URL.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -340,7 +340,7 @@ The following example displays an output without the name of the organization-le
 
 The **Remedy** output will stream notifications and alerts to a specified Remedy URL.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -380,7 +380,7 @@ The **Azure Event Hub Trigger** output will stream notifications and alerts to a
 > 
 >   * To learn how to create an Azure AD token, review this [document from Microsoft](https://docs.microsoft.com/en-us/rest/api/eventhub/get-azure-active-directory-token).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |

--- a/docs/configuration/outputs-streams.md
+++ b/docs/configuration/outputs-streams.md
@@ -21,7 +21,7 @@ An **Output - Stream** focuses on centralized monitoring platforms. Specifically
 
 ## Step 1: Review Feature Types
 
-In the Edge Delta Admin portal, **features** are the data types that the Edge Delta agent should collect (or generate), and then send to a streaming destination.
+In the Edge Delta App, **features** are the data types that the Edge Delta agent should collect (or generate), and then send to a streaming destination.
 
 When you create an **Output - Stream**, you can add the following features to the output:
 
@@ -47,7 +47,7 @@ At a high level, there are 2 ways to manage **Outputs - Streams**:
 
 ### Option 1: Access the visual editor for a new configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Streams**.
@@ -63,7 +63,7 @@ At a high level, there are 2 ways to manage **Outputs - Streams**:
 
 ### Option 2: Access the YAML file for an existing configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file, make your changes, and then click **Save**.
 
@@ -86,7 +86,7 @@ The Splunk output will stream analytics and insights to a Splunk HEC endpoint.
 >
 >   * To learn how to create and obtain this information, see [Supplemental Information for Splunk Integration](#supplemental-information-for-splunk-integration).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -113,7 +113,7 @@ The following example displays when the name of the organization-level integrati
       - integration_name: my-org-splunk
 ```
 
-The following example displays if there are multiple instances of the same desitnation that need to route different data types to different Splunk indexes:
+The following example displays if there are multiple instances of the same destination that need to route different data types to different Splunk indexes:
 
 ```yaml
 - name: edac-splunk-dest
@@ -139,7 +139,7 @@ The Sumo Logic output will stream analytics and insights to a Sumo Logic HTTPs E
 >   * To learn how to create new Sumo Logic HTTPs endpoint, review this [document from Sumo Logic](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source#access-a-sources-url).
 >   * To learn how to locate an existing Sumo Logic HTTPs endpoint, review this [document from Sumo Logic](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source#access-a-sources-url).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional|
 | :--- | :--- | :--- |
@@ -170,7 +170,7 @@ The AWS CloudWatch output will stream logs to a specified AWS region.
 >   * To learn how to create a log group, review this [document from Amazon](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html).
 >   * To learn how to create a log stream, review this [document from Amazon](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional|
 | :--- | :--- | :--- |
@@ -244,7 +244,7 @@ The Datadog output will stream analytics and insights to a Datadog environment.
 >
 >   * To learn how to create a new Datadog API key, review this [document from Datadog](https://docs.datadoghq.com/account_management/api-app-keys/#add-a-key).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -293,7 +293,7 @@ The New Relic output will stream analytics and insights to a New Relic environme
 >
 >   * To learn how to create new New Relic Insert API key, review this [document from New Relic](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#event-insert-key).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -323,7 +323,7 @@ The Honeycomb output will stream analytics and insights to a Honeycomb environme
 >
 >   * To learn how to create new Honeycomb API key, review this [document from Honeycomb](https://docs.honeycomb.io/api/api-keys/#manage-api-keys).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -367,7 +367,7 @@ The AppDynamics output will stream analytics and insights to an AppDynamics envi
 >   * To find your Global Account name, review this [document from AppDynamics](https://docs.appdynamics.com/21.1/en/application-monitoring/install-app-server-agents/agent-to-controller-connections#Agent-to-ControllerConnections-findaccountFindYourAccountNameandAccessKey).
 >   * To learn how to create new AppDynamics API key, review this [document from AppDynamics](https://docs.appdynamics.com/21.2/en/analytics/deploy-analytics-with-the-analytics-agent/analytics-and-data-security/manage-api-keys#ManageAPIKeys-CreateAPIKeys).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -403,7 +403,7 @@ The following example displays an output without the name of the organization-le
 
 The InfluxDB output will stream analytics and insights to your InfluxDB deployment.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -446,7 +446,7 @@ The following example displays an output without the name of the organization-le
 
 The Wavefront output will stream analytics and insights to your Wavefront environment.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -472,7 +472,7 @@ The following example displays an output without the name of the organization-le
 
 The Scalyr output will stream analytics and insights to your Scalyr environment.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -499,7 +499,7 @@ The **Elastic Search** output will stream analytics and insights to your Elastic
 > **Before you begin**
 >
 > Edge Delta recommends that you review and complete the steps listed in the [elastic index template and lifecycle creation guide](../appendices/elastic-index.md).
-> This process will help you prepare your Elastic Search environment to become an Edge Detla streaming target.
+> This process will help you prepare your Elastic Search environment to become an Edge Delta streaming target.
 
 <br>
 
@@ -508,7 +508,7 @@ The **Elastic Search** output will stream analytics and insights to your Elastic
 > For **connection url**, you must provide either the **cloud\_id** or **address**. You cannot enter both parameters.
 > For the **authentication**, you must provide either the **token** or the **user/password**. You cannot enter both parameters.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -529,7 +529,7 @@ The following example displays an output without the name of the organization-le
       - name: elastic-integration
         type: elastic
         index: "index name"
-        # you can provide cloud or adress list but not both at the same time
+        # you can provide cloud or address list but not both at the same time
         cloud_id: "<add elasticsearch cloud_id>"
         #address:
          #- <elastic search endpoint address_1>
@@ -546,7 +546,7 @@ The following example displays an output without the name of the organization-le
 
 The **Azure AppInsight** output will stream analytics and insights to your Azure endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -573,7 +573,7 @@ The following example displays an output without the name of the organization-le
 
 The **Kafka** output will stream analytics and insights to your Kafka endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -600,7 +600,7 @@ The following example displays an output without the name of the organization-le
 
 The **SignalFx** output will stream analytics and insights to your SignalFx endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -627,7 +627,7 @@ The following example displays an output without the name of the organization-le
 
 The **Humio** output will stream analytics and insights to your Humio endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -654,7 +654,7 @@ The following example displays an output without the name of the organization-le
 
 The **Loggly** output will stream analytics and insights to your Loggly endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional|
 | :--- | :--- | :--- |
@@ -681,7 +681,7 @@ The following example displays an output without the name of the organization-le
 
 The **Logz.io** output will stream analytics and insights to your Logz.io endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -713,7 +713,7 @@ The following example displays an output without the name of the organization-le
 
 The **Loki** output will stream analytics and insights to your Loki endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -790,7 +790,7 @@ The following example displays an output without the name of the organization-le
 
 The **FluentD** output will stream analytics and insights to your FluentD endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -827,7 +827,7 @@ The **Azure Event Hub Stream** output will stream analytics and insights to your
 >
 >   * To learn how to create an Azure AD token, review this [document from Microsoft](https://docs.microsoft.com/en-us/rest/api/eventhub/get-azure-active-directory-token).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -892,7 +892,7 @@ Before you can set up a Splunk output, you must have the HEC token and HEC endpo
 3. In the field, enter a name for the HEC, and then click **Next**.
 4. Confirm the index information or use the default index, and then click **Click Review**.
 5. Click **Submit**.
-6. Copy the displayed token value. You can enter this information in the **Token** field in the Edge Delta Admin portal.
+6. Copy the displayed token value. You can enter this information in the **Token** field in the Edge Delta App.
 
 #### Option 2: Splunk Enterprise
 
@@ -910,7 +910,7 @@ Before you can set up a Splunk output, you must have the HEC token and HEC endpo
 3. In the field, enter a name for the HEC, and then click **Next**.
 4. Confirm the index information or use the default index, and then click **Click Review**.
 5. Click **Submit**.
-6. Copy the displayed token value. You can enter this information in the **Token** field in the Edge Delta Admin portal.
+6. Copy the displayed token value. You can enter this information in the **Token** field in the Edge Delta App.
 
 ### Step 2: Determine your HEC Endpoint
 

--- a/docs/configuration/outputs-triggers.md
+++ b/docs/configuration/outputs-triggers.md
@@ -30,7 +30,7 @@ At a high level, there are 2 ways to manage **Outputs**:
 
 ### Option 1: Access the visual editor for a new configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Triggers**.
@@ -46,7 +46,7 @@ At a high level, there are 2 ways to manage **Outputs**:
 
 ### Option 2: Access the YAML file for an existing configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file, make your changes, and then click **Save**. 
 
@@ -69,7 +69,7 @@ The **Slack** output will stream notifications and alerts to a specified Slack c
 > 
 >   * To learn more about webhooks, review [this document from Slack](https://api.slack.com/messaging/webhooks).
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -78,7 +78,7 @@ Review the following parameters that you can configure in the Edge Delta Admin p
 | type | You must set this parameter to **slack**.| Required |
 | endpoint | Enter the Slack Webhook or APP endpoint URL. | Required |
 | suppression\_window | Enter a [golang duration](https://golang.org/pkg/time/#ParseDuration) string that represents the suppression window. Once the agent detects an issue and notifies the Slack endpoint, the agent will suppress any new issues for this time period. The default setting is **20m**. | Optional |
-| suppression\_mode | Enter a supression mode, which can be **local** or **global**. The default mode is **local**, which indicates that an individual agent suppresses an issue if the agent has already made a local notification for a similar issue in the last suppresson window. **Global** mode indicates that an individual agent checks with the Edge Delta backend to see if there were similar alerts from other sibling agents \(agents that share the same tag in the configuration\). | Optional |
+| suppression\_mode | Enter a supression mode, which can be **local** or **global**. The default mode is **local**, which indicates that an individual agent suppresses an issue if the agent has already made a local notification for a similar issue in the last suppression window. **Global** mode indicates that an individual agent checks with the Edge Delta backend to see if there were similar alerts from other sibling agents \(agents that share the same tag in the configuration\). | Optional |
 | notify\_content | You can use this parameter to customize the notification content. This parameter supports templating. To learn more, see [(Optional) Step 3: Review Notify Content Parameters](#optional-step-3-review-notify-content-parameters). | Optional |
 
 The following example displays an output without the name of the organization-level integration:
@@ -104,7 +104,7 @@ The following example displays an output without the name of the organization-le
 
 The **Microsoft Teams** output will stream notifications and alerts to a specified Teams channel.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -113,7 +113,7 @@ Review the following parameters that you can configure in the Edge Delta Admin p
 | type | Select **teams**. | Required |
 | endpoint | Enter the Microsoft Teams webhook URL. | Required |
 | suppression\_window | Enter a [golang duration](https://golang.org/pkg/time/#ParseDuration) string that represents the suppression window. Once the agent detects an issue and notifies the Slack endpoint, the agent will suppress any new issues for this time period. The default setting is **20m**.| Optional |
-| suppression\_mode | Enter a supression mode, which can be **local** or **global**. The default mode is **local**, which indicates that an individual agent suppresses an issue if the agent has already made a local notification for a similar issue in the last suppresson window. **Global** mode indicates that an individual agent checks with the Edge Delta backend to see if there were similar alerts from other sibling agents \(agents that share the same tag in the configuration\).  | Optional |
+| suppression\_mode | Enter a supression mode, which can be **local** or **global**. The default mode is **local**, which indicates that an individual agent suppresses an issue if the agent has already made a local notification for a similar issue in the last suppression window. **Global** mode indicates that an individual agent checks with the Edge Delta backend to see if there were similar alerts from other sibling agents \(agents that share the same tag in the configuration\).  | Optional |
 | notify\_content | You can use this parameter to customize the notification content. This parameter supports templating. To learn more, see [(Optional) Step 3: Review Notify Content Parameters](#optional-step-3-review-notify-content-parameters).| Optional |
 
 The following example displays an output without the name of the organization-level integration:
@@ -139,7 +139,7 @@ The following example displays an output without the name of the organization-le
 
 The **Pagerduty** output will stream notifications and alerts to a specified Pagerduty API endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -180,7 +180,7 @@ The following example displays an output without the name of the organization-le
 
 The **Jira** output will stream notifications and alerts to a specified Jira webhook URL.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -212,7 +212,7 @@ The following example displays an output without the name of the organization-le
 
 The **Service Now** output will stream notifications and alerts to a specified Service Now API endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -247,7 +247,7 @@ The following example displays an output without the name of the organization-le
 
 The **Webhook** output will stream notifications and alerts to the specified Webhook URL.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -292,7 +292,7 @@ The following example displays an output without the name of the organization-le
 
 The **AWS Lambda** output will stream notifications and alerts to  the specified AWS Lambda FaaS endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |
@@ -323,7 +323,7 @@ The following example displays an output without the name of the organization-le
 
 The **Azure Functions** output will stream notifications and alerts to Azure endpoint.
 
-Review the following parameters that you can configure in the Edge Delta Admin portal:
+Review the following parameters that you can configure in the Edge Delta App:
 
 | Parameter | Description | Required or Optional |
 | :--- | :--- | :--- |

--- a/docs/configuration/outputs.md
+++ b/docs/configuration/outputs.md
@@ -102,7 +102,7 @@ There are 2 ways to create an output. You can create an output at the organizati
 
 ### Option 1: Create an Output at the Organization Level
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Integrations**.
+1. In the Edge Delta App, on the left-side navigation, click **Integrations**.
 2. Under **Add Integrations**, select the desired destination and output type.
 3. Complete the missing fields, and then click **Save**.
 
@@ -116,7 +116,7 @@ There are 2 ways to create an output. You can create an output at the organizati
 
 ### Option 2: Create an Output for a New Configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Streams**, **Triggers**, or **Archives**.
@@ -133,7 +133,7 @@ There are 2 ways to create an output. You can create an output at the organizati
 > 
 > To add an output to an existing configuration, you must access the configuration's YAML file. Additionally, to make changes outside of the visual editor, you can access the configuration's YAML file.
 > 
->  1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+>  1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 >  2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 >  3. Review the YAML file, make your changes, and then click **Save**.  
 

--- a/docs/configuration/variables.md
+++ b/docs/configuration/variables.md
@@ -58,7 +58,7 @@ In certain cases, it is useful to set a variable in a simple way. For example, o
 
 > **Note**
 > 
-> To learn how to set or override variables, review the **Configuration Variables** table in the [Global Settings](https://admin.edgedelta.com/global-settings) page in the Edge Delta Admin portal. The agent will automatically detect variable updates.
+> To learn how to set or override variables, review the **Configuration Variables** table in the [Global Settings](https://app.edgedelta.com/global-settings) page in the Edge Delta App. The agent will automatically detect variable updates.
 
 Review the following examples of configuration variables:
 

--- a/docs/configuration/workflows.md
+++ b/docs/configuration/workflows.md
@@ -37,7 +37,7 @@ At a high level, there are 2 ways to manage **Workflows**:
 > 
 > To create a new workflow, you must have existing inputs, processors, destinations, thresholds, and filters to add to the new workflow. You cannot create a workflow without these existing components.  
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Click **Visual**.
 4. On the right-side, select **Workflows**. 
@@ -51,7 +51,7 @@ At a high level, there are 2 ways to manage **Workflows**:
 
 ### Option 2: Access the YAML file for an existing configuration
 
-1. In the Edge Delta Admin portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Locate the desired configuration, and then under **Actions**, click the corresponding edit icon.
 3. Review the YAML file, make your changes, and then click **Save**. 
 

--- a/docs/installation/amazon-ecs.md
+++ b/docs/installation/amazon-ecs.md
@@ -14,7 +14,7 @@ You can use this document to learn how to deploy the Edge Delta Agent as a Daemo
 
 ## Step 1: Create a Configuration 
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select the desired platform.
 4. Click **Save**.  
@@ -62,7 +62,7 @@ While you can use the agent as an ordinary ECS task, you will only collect logs 
 ## Step 4: Verify Defintions and Configurations
 
 1. Verify that the container definition for other tasks or services does not have the`logConfiguration.logDriver` parameter. Without a logging driver, logs are written to standard output and collected by the agent service.
-2. In the Edge Delta Admin portal, in the left-side navigation, click **Agent Settings**. Locate the agent configuration, and then click the edit icon. 
+2. In the Edge Delta App, in the left-side navigation, click **Agent Settings**. Locate the agent configuration, and then click the edit icon. 
 3. In the agent YAML configuration file, verify that you have the container input source is enabled. Review the following example to view how to collect container logs:
 
 ```yaml

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -20,7 +20,7 @@ Edge Delta has a Docker container image that can be deployed as a Sidecar or Dae
 
 ## Step 1: Create a Configuration and Download the Agent
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select **Docker**.
 4. Click **Save**.  

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -26,7 +26,7 @@ Edge Delta uses a Kubernetes-recommended, node-level log collecting architecture
 
 ## Create a Configuration and Install the Agent via Helm 
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**. 
 3. Select **Helm**.
 4. Click **Save**.  
@@ -96,7 +96,7 @@ STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-1. Visit https://admin.edgedelta.com
+1. Visit https://app.edgedelta.com
 2. Find the configuration with <API-KEY> to check if agents are active
 ```
 
@@ -121,7 +121,7 @@ helm ls -n edgedelta
 
 | Name | Description | Example Value |
 | :--- | :--- | :--- |
-| apiKey | API Key used to pull agent's configuration details (generated via ED Admin Portal), should not be specified when secretApiKey is set | "8d32..." |
+| apiKey | API Key used to pull agent's configuration details (generated via the Edge Delta App), should not be specified when secretApiKey is set | "8d32..." |
 | secretApiKey.name | Reference to Edge Delta Agent API Key secret name in same namespace, should not be specified when apiKey is set | "ed-api-key" |
 | storePort | Reference to Edge Delta Agent API Key secret key in same namespace, should not be specified when apiKey is set | "ed-api-key" |
 | httpProxy | Proxy details for routing Edge Delta agent's outbound traffic through an HTTP internal proxy | "http://127.0.0.1:3128" |

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -12,7 +12,7 @@ The Edge Delta installation package is available and fully supported on hosts th
 
 Additionally, a Docker image is available for containerized environments.
 
-Review the following installaiton documents: 
+Review the following installation documents: 
 
 * [Windows](windows.md)
 * [Linux](linux.md)

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -6,9 +6,13 @@ description: >-
 
 # Installation
 
-The Edge Delta installation package is available and fully supported for install on hosts running Windows, Linux, and MacOS operating systems. A Docker image is also available for containerized environments.
+## Overview 
 
-Select from the following deployment types below to review the appropriate documentation:
+The Edge Delta installation package is available and fully supported on hosts that run Windows, Linux, and MacOS operating systems. 
+
+Additionally, a Docker image is available for containerized environments.
+
+Review the following installaiton documents: 
 
 * [Windows](windows.md)
 * [Linux](linux.md)
@@ -18,16 +22,12 @@ Select from the following deployment types below to review the appropriate docum
 * [Kubernetes via Helm](helm.md)
 * [AWS ECS](amazon-ecs.md)
 
-In addition - within the admin console, many of the commands needed for installation can be created for you automatically through the wizard.
+***
 
-To configure specific environment variables for your agents see [Environment Variables](environment-variables.md).
+## Additional Documentation
 
-If you have a deployment environment with restricted outgoing network policy see [Agent Network Access Requirements](network-access.md).
+To configure specific environment variables for your agents, see [Environment Variables](environment-variables.md).
 
-Linux Example:
+If you have a deployment environment with restricted outgoing network policies, see [Agent Network Access Requirements](network-access.md).
 
-![](../assets/edge_delta_deploy.jpg)
-
-Kubernetes Example:
-
-![](../assets/edge_delta_dk8s.jpg)
+***

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -27,7 +27,7 @@ Edge Delta uses a Kubernetes-recommended, node-level logging architecture, also 
 
 ## Step 1: Create a Configuration and Download and Install the Agent
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select **Kubernetes**.
 4. Click **Save**.  

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -19,7 +19,7 @@ You can use this document to learn how to install the Edge Delta Agent for your 
 
 ## Step 1: Create a Configuration and Download the Agent
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select **Linux**.
 4. Click **Save**.  

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -18,7 +18,7 @@ You can use this document to learn how to install the Edge Delta Agent for your 
 
 ## Step 1: Create a Configuration and Download the Agent
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select **MacOS**.
 4. Click **Save**.  

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -20,7 +20,7 @@ Edge Delta uses 64-bit or 32-bit MSI installation process.
 
 ## Step 1: Create a Configuration and Download the Agent
 
-1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 2. Click **Create Configuration**.
 3. Select **Windows**.
 4. Click **Save**.  
@@ -63,7 +63,7 @@ start /wait msiexec /qn /i edgedelta-version_64bit.msi APIKEY="<YOUR_API_KEY>"
 
 > To automate:
 
-> 1. In the Edge Delta Admin Portal, on the left-side navigation, click **Agent Settings**.
+> 1. In the Edge Delta App, on the left-side navigation, click **Agent Settings**.
 
 > 2. In the list of configurations, locate the **Windows** tag, and then click the corresponding deploy icon (green rocket).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,4 +59,3 @@ nav:
     - Create an Okta SAML Integration: appendices/okta-saml.md
     - Tokens: appendices/tokens.md
     - On-Prem Rehydrations: appendices/on-prem-rehydration.md
-  - Release Notes: release-notes.md    


### PR DESCRIPTION
Updating several pages to:

- Remove release notes from left-side nav 
- Update for spelling errors
- Replace “admin portal” with “app”