### PR TITLE
Add container port to rehydration handler deployment yml

### DIFF
--- a/docs/appendices/on-prem-rehydration-handler-faasless.yml
+++ b/docs/appendices/on-prem-rehydration-handler-faasless.yml
@@ -17,9 +17,11 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       containers:
-      - name: poller
+      - name: handler
         # image built on 2021-11-18
         image: gcr.io/edgedelta/function@sha256:3be42c1acf1887025e602d8d91c76462375ca5af789255b4365487ab129e9e12
+        ports:
+          - containerPort: 8080
         command:
           - /edgedelta/faas
         env:


### PR DESCRIPTION
The port wasn't exposed from container so the service was timing out.
Matt notified customer to try this fix. Waiting for them to confirm before merging